### PR TITLE
feat(form-generator): implement public form submission with Supabase storage

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -44,3 +44,33 @@ export const DELETE_FORM = gql`
     }
   }
 `;
+
+export const GET_FORM_BY_ID = gql`
+  query GetFormById($id: uuid!) {
+    formsCollection(filter: { id: { eq: $id } }) {
+      edges {
+        node {
+          id
+          title
+          description
+          schema
+          created_at
+          updated_at
+        }
+      }
+    }
+  }
+`;
+
+export const SUBMIT_FORM_RESPONSE = gql`
+  mutation SubmitFormResponse($objects: [form_submissionsInsertInput!]!) {
+    insertIntorowsCollection(objects: $objects) {
+      records {
+        id
+        form_id
+        data
+        created_at
+      }
+    }
+  }
+`;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,8 +6,8 @@ import ServicesPage from "./routes/services";
 import ContactPage from "./routes/contact";
 import NotFoundPage from "./routes/not-found";
 import FormGenerator from "./routes/form/form-generator";
-import FormRenderer from "./routes/form/form-renderer";
 import FormList from "./routes/form/form-list";
+import SubmitForm from "./routes/form/submit-form";
 
 export const router = createBrowserRouter([
   {
@@ -44,9 +44,9 @@ export const router = createBrowserRouter([
         path: "generator",
         element: <FormGenerator/>
       },
-      {
-        path: "renderer",
-        element: <FormRenderer/>
+       {
+        path: "submit/:id",
+        element: <SubmitForm/>
       },
       {
         index: true,

--- a/src/routes/form/form-list.tsx
+++ b/src/routes/form/form-list.tsx
@@ -1,34 +1,42 @@
-import { useQuery, useMutation } from '@apollo/client/react';
-import { GET_FORMS, DELETE_FORM } from '@/graphql/queries';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { useQuery, useMutation } from "@apollo/client/react";
+import { GET_FORMS, DELETE_FORM } from "@/graphql/queries";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { 
-  Eye, 
-  Edit, 
-  Trash2, 
-  Copy, 
-  Calendar, 
+import {
+  Eye,
+  Edit,
+  Trash2,
+  Copy,
+  Calendar,
   FileText,
   RefreshCw,
-  Plus
+  Plus,
+  LayersPlus,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Link } from "react-router-dom";
-import type { Form, FormEdge } from '@/types/form';
+import type { Form, FormEdge } from "@/types/form";
 
 export default function FormList() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  
+
   const { loading, error, data, refetch } = useQuery(GET_FORMS);
   const [deleteForm] = useMutation(DELETE_FORM, {
     update(cache, { data: { deleteFromformsCollection } }) {
       if (deleteFromformsCollection?.records?.length > 0) {
         const deletedId = deleteFromformsCollection.records[0].id;
-        
+
         cache.modify({
           fields: {
             formsCollection(existingCollection, { readField }) {
@@ -36,14 +44,14 @@ export default function FormList() {
               return {
                 ...existingCollection,
                 edges: edges.filter(
-                  (edge: FormEdge) => readField('id', edge.node) !== deletedId
-                )
+                  (edge: FormEdge) => readField("id", edge.node) !== deletedId
+                ),
               };
-            }
-          }
+            },
+          },
         });
       }
-    }
+    },
   });
 
   const handleDelete = async (id: string, title: string) => {
@@ -56,8 +64,8 @@ export default function FormList() {
       await deleteForm({ variables: { id } });
       toast.success(`Form "${title}" deleted successfully`);
     } catch (err: any) {
-      toast.error('Failed to delete form');
-      console.error('Delete error:', err);
+      toast.error("Failed to delete form");
+      console.error("Delete error:", err);
     } finally {
       setDeletingId(null);
     }
@@ -69,12 +77,12 @@ export default function FormList() {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
+    return new Date(dateString).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
   };
 
@@ -93,7 +101,7 @@ export default function FormList() {
             </div>
             <Skeleton className="h-10 w-32" />
           </div>
-          
+
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[1, 2, 3].map((i) => (
               <Card key={i}>
@@ -123,11 +131,7 @@ export default function FormList() {
             Error loading forms: {error.message}
           </AlertDescription>
         </Alert>
-        <Button 
-          onClick={() => refetch()} 
-          variant="outline" 
-          className="mt-4"
-        >
+        <Button onClick={() => refetch()} variant="outline" className="mt-4">
           <RefreshCw className="w-4 h-4 mr-2" />
           Retry
         </Button>
@@ -135,7 +139,8 @@ export default function FormList() {
     );
   }
 
-  const forms = data?.formsCollection?.edges?.map((edge: FormEdge) => edge.node) || [];
+  const forms =
+    data?.formsCollection?.edges?.map((edge: FormEdge) => edge.node) || [];
 
   return (
     <div className="container mx-auto p-6">
@@ -148,14 +153,14 @@ export default function FormList() {
               Create, manage, and view all your form schemas
             </p>
           </div>
-          
+
           <div className="flex items-center gap-2">
             <Button variant="outline" onClick={() => refetch()}>
               <RefreshCw className="w-4 h-4 mr-2" />
               Refresh
             </Button>
             <Link to="/form/generator">
-              <Button className='cursor-pointer'>
+              <Button className="cursor-pointer">
                 <Plus className="w-4 h-4 mr-2" />
                 Create Form
               </Button>
@@ -173,7 +178,7 @@ export default function FormList() {
                 Create your first form to get started
               </p>
               <Link to="/form/generator">
-                <Button className='cursor-pointer'>
+                <Button className="cursor-pointer">
                   <Plus className="w-4 h-4 mr-2" />
                   Create Your First Form
                 </Button>
@@ -201,26 +206,26 @@ export default function FormList() {
                     </Badge>
                   </div>
                 </CardHeader>
-                
+
                 <CardContent>
                   <div className="space-y-3">
-
-                    
                     {form.schema?.fields && (
                       <div className="pt-2">
                         <p className="text-sm font-medium mb-2">Field Types:</p>
                         <div className="flex flex-wrap gap-1">
                           {Array.from(
                             new Set(form.schema.fields.map((f: any) => f.type))
-                          ).slice(0, 3).map((type: string) => (
-                            <Badge 
-                              key={type as string} 
-                              variant="secondary" 
-                              className="text-xs"
-                            >
-                              {type}
-                            </Badge>
-                          ))}
+                          )
+                            .slice(0, 3)
+                            .map((type: string) => (
+                              <Badge
+                                key={type as string}
+                                variant="secondary"
+                                className="text-xs"
+                              >
+                                {type}
+                              </Badge>
+                            ))}
                           {form.schema.fields.length > 3 && (
                             <Badge variant="secondary" className="text-xs">
                               +{form.schema.fields.length - 3} more
@@ -231,7 +236,7 @@ export default function FormList() {
                     )}
                   </div>
                 </CardContent>
-                
+
                 <CardFooter className="flex justify-between border-t pt-4">
                   {/* <div className="flex gap-2">
                     <Link to={`/form-generator?edit=${form.id}`}>
@@ -240,9 +245,18 @@ export default function FormList() {
                       </Button>
                     </Link>
                   </div> */}
-                  
+                  <Link to={`/form/submit/${form.id}`}>
+                    <Button
+                      className="cursor-pointer"
+                      size="sm"
+                    >
+                      <LayersPlus />
+                      <span>Data Entry</span>
+                    </Button>
+                  </Link>
+
                   <Button
-                    className='cursor-pointer'
+                    className="cursor-pointer"
                     size="sm"
                     variant="destructive"
                     onClick={() => handleDelete(form.id, form.title)}
@@ -259,7 +273,6 @@ export default function FormList() {
             ))}
           </div>
         )}
-
       </div>
     </div>
   );

--- a/src/routes/form/form-renderer.tsx
+++ b/src/routes/form/form-renderer.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-function FormRenderer() {
-  return (
-    <div>FormRenderer</div>
-  )
-}
-
-export default FormRenderer

--- a/src/routes/form/submit-form.tsx
+++ b/src/routes/form/submit-form.tsx
@@ -1,0 +1,538 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery, useMutation } from "@apollo/client/react";
+import { GET_FORM_BY_ID, SUBMIT_FORM_RESPONSE } from "@/graphql/queries";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { 
+  ArrowLeft, 
+  CheckCircle, 
+  Send, 
+  RefreshCw,
+  AlertCircle,
+  PlusCircle
+} from "lucide-react";
+import { toast } from "sonner";
+
+interface FormField {
+  id: string;
+  type: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+}
+
+interface FormSchema {
+  fields: FormField[];
+}
+
+export default function SubmitForm() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  
+  const [formData, setFormData] = useState<Record<string, any>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [fields, setFields] = useState<FormField[]>([]);
+  const [formTitle, setFormTitle] = useState("");
+  const [formDescription, setFormDescription] = useState("");
+
+  // Fetch form schema
+  const { loading, error, data, refetch } = useQuery(GET_FORM_BY_ID, {
+    variables: { id },
+    skip: !id,
+  });
+
+  // Submit mutation
+  const [submitForm, { loading: submitting }] = useMutation(SUBMIT_FORM_RESPONSE);
+
+  // Get form details and parse schema
+  useEffect(() => {
+    if (data?.formsCollection?.edges?.[0]?.node) {
+      const form = data.formsCollection.edges[0].node;
+      setFormTitle(form.title || "");
+      setFormDescription(form.description || "");
+      
+      let parsedFields: FormField[] = [];
+      
+      try {
+        // Try to parse the schema if it's a string
+        let schema: FormSchema | string = form.schema;
+        
+        if (typeof schema === 'string') {
+          schema = JSON.parse(schema);
+        }
+        
+        if (schema && typeof schema === 'object' && 'fields' in schema) {
+          parsedFields = schema.fields || [];
+        }
+        
+        console.log("Parsed fields:", parsedFields);
+      } catch (parseError) {
+        console.error("Error parsing schema:", parseError);
+        toast.error("Error loading form structure");
+      }
+      
+      setFields(parsedFields);
+      
+      // Initialize form data structure
+      const initialData: Record<string, any> = {};
+      parsedFields.forEach((field: FormField) => {
+        // Set default values based on field type
+        switch (field.type) {
+          case 'checkbox':
+            initialData[field.id] = false;
+            break;
+          case 'number':
+            initialData[field.id] = '';
+            break;
+          default:
+            initialData[field.id] = '';
+        }
+      });
+      setFormData(initialData);
+    }
+  }, [data]);
+
+  const handleInputChange = (fieldId: string, value: any) => {
+    setFormData(prev => ({
+      ...prev,
+      [fieldId]: value
+    }));
+    
+    // Clear error for this field if it exists
+    if (errors[fieldId]) {
+      setErrors(prev => {
+        const newErrors = { ...prev };
+        delete newErrors[fieldId];
+        return newErrors;
+      });
+    }
+  };
+
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+    
+    fields.forEach((field: FormField) => {
+      const value = formData[field.id];
+      
+      // Check required fields
+      if (field.required) {
+        if (field.type === 'checkbox') {
+          if (!value) {
+            newErrors[field.id] = `${field.label} is required`;
+          }
+        } else if (!value || value.toString().trim() === '') {
+          newErrors[field.id] = `${field.label} is required`;
+        }
+      }
+      
+      // Email validation
+      if (field.type === 'email' && value && value.trim() !== '') {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(value)) {
+          newErrors[field.id] = 'Please enter a valid email address';
+        }
+      }
+      
+      // Number validation
+      if (field.type === 'number' && value && value.trim() !== '') {
+        if (isNaN(Number(value))) {
+          newErrors[field.id] = 'Please enter a valid number';
+        }
+      }
+    });
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!validateForm()) {
+      toast.error("Please fix the errors in the form");
+      return;
+    }
+
+    try {
+      // Prepare submission data - stringify the data field
+      const submissionData = {
+        form_id: id,
+        data: JSON.stringify(formData), // Stringify the data
+        created_at: new Date().toISOString()
+      };
+
+      console.log("Submitting data:", submissionData);
+
+      const result = await submitForm({
+        variables: {
+          objects: [submissionData]
+        }
+      });
+
+      console.log("Submission result:", result);
+
+      if (result.data?.insertIntorowsCollection?.records?.length > 0) {
+        // Set submitted state to show success message
+        setIsSubmitted(true);
+        toast.success("Form submitted successfully!");
+        
+        // Clear errors
+        setErrors({});
+        
+      } else {
+        toast.error("Failed to submit form - no records returned");
+      }
+      
+    } catch (error: any) {
+      console.error("Submission error:", error);
+      toast.error(`Failed to submit: ${error.message}`);
+    }
+  };
+
+  const handleSubmitAnother = () => {
+    // Reset form for another submission
+    setIsSubmitted(false);
+    
+    // Reset form data
+    const resetData: Record<string, any> = {};
+    fields.forEach((field: FormField) => {
+      switch (field.type) {
+        case 'checkbox':
+          resetData[field.id] = false;
+          break;
+        default:
+          resetData[field.id] = '';
+      }
+    });
+    setFormData(resetData);
+    setErrors({});
+    
+    // Refocus on the form
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const renderField = (field: FormField) => {
+    const fieldError = errors[field.id];
+    const isRequired = field.required;
+    const fieldValue = formData[field.id] || '';
+    
+    const baseProps = {
+      id: field.id,
+      required: isRequired,
+      placeholder: field.placeholder || '',
+      className: fieldError ? "border-red-500" : "",
+    };
+
+    switch (field.type) {
+      case 'textarea':
+        return (
+          <Textarea 
+            {...baseProps}
+            value={fieldValue}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => 
+              handleInputChange(field.id, e.target.value)
+            }
+            rows={4}
+          />
+        );
+      
+      case 'select':
+        return (
+          <Select
+            value={fieldValue}
+            onValueChange={(value) => handleInputChange(field.id, value)}
+          >
+            <SelectTrigger className={fieldError ? "border-red-500" : ""}>
+              <SelectValue placeholder={field.placeholder || "Select an option"} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="option1">Option 1</SelectItem>
+              <SelectItem value="option2">Option 2</SelectItem>
+              <SelectItem value="option3">Option 3</SelectItem>
+            </SelectContent>
+          </Select>
+        );
+      
+      case 'checkbox':
+        return (
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id={field.id}
+              checked={!!fieldValue}
+              onCheckedChange={(checked) => handleInputChange(field.id, checked)}
+              className={fieldError ? "border-red-500" : ""}
+            />
+            <label
+              htmlFor={field.id}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              {field.placeholder || field.label}
+            </label>
+          </div>
+        );
+      
+      default:
+        return (
+          <Input
+            type={field.type}
+            {...baseProps}
+            value={fieldValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => 
+              handleInputChange(field.id, e.target.value)
+            }
+          />
+        );
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <Card className="w-full max-w-2xl">
+          <CardHeader>
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <Card className="w-full max-w-2xl">
+          <CardContent className="pt-6">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Error loading form: {error.message}
+              </AlertDescription>
+            </Alert>
+            <Button 
+              onClick={() => navigate("/forms")} 
+              variant="outline" 
+              className="w-full mt-4"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back to Forms
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!data?.formsCollection?.edges?.[0]?.node) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <Card className="w-full max-w-2xl">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <h2 className="text-xl font-semibold mb-2">Form Not Found</h2>
+            <p className="text-muted-foreground mb-4">
+              The form you're looking for doesn't exist or has been removed.
+            </p>
+            <Button 
+              onClick={() => navigate("/forms")} 
+              variant="outline"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back to Forms
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-4">
+      <div className="max-w-2xl mx-auto">
+        {/* Success State - Shows after submission */}
+        {isSubmitted ? (
+          <Card className="border-green-200 shadow-lg">
+            <CardContent className="pt-12 pb-12 text-center">
+              <div className="flex justify-center mb-6">
+                <div className="rounded-full bg-green-100 p-4">
+                  <CheckCircle className="h-16 w-16 text-green-600" />
+                </div>
+              </div>
+              
+              <h1 className="text-3xl font-bold mb-4 text-green-700">
+                Successfully Submitted!
+              </h1>
+              
+              <p className="text-lg text-muted-foreground mb-2">
+                Thank you for submitting <span className="font-semibold">{formTitle}</span>
+              </p>
+              
+              <p className="text-muted-foreground mb-8">
+                Your response has been recorded successfully.
+              </p>
+              
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Button
+                  onClick={handleSubmitAnother}
+                  size="lg"
+                  className="bg-green-600 hover:bg-green-700"
+                >
+                  <PlusCircle className="w-5 h-5 mr-2" />
+                  Submit Another Response
+                </Button>
+                
+                <Button
+                  onClick={() => navigate("/form")}
+                  variant="outline"
+                  size="lg"
+                >
+                  <ArrowLeft className="w-5 h-5 mr-2" />
+                  Back to Forms List
+                </Button>
+              </div>
+              
+              <div className="mt-8 pt-6 border-t">
+                <p className="text-sm text-muted-foreground">
+                  Need to make changes? Click "Submit Another Response" to fill out the form again.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Form Header - Only shows when NOT in submitted state */}
+            <div className="mb-8">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate("/forms")}
+                className="mb-4"
+              >
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Back to Forms
+              </Button>
+              
+              <h1 className="text-3xl font-bold mb-2">{formTitle}</h1>
+              
+              {formDescription && (
+                <p className="text-muted-foreground mb-4">{formDescription}</p>
+              )}
+              
+              <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+                <div className="w-2 h-2 rounded-full bg-green-500"></div>
+                <span>Form is active and accepting responses</span>
+              </div>
+              
+              {fields.length === 0 && (
+                <Alert>
+                  <AlertDescription>
+                    This form has no fields to submit.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+
+            {/* Form - Only shows when NOT in submitted state */}
+            {fields.length > 0 ? (
+              <Card className="mb-8">
+                <CardHeader>
+                  <CardTitle>Fill out the form</CardTitle>
+                  <CardDescription>
+                    Please provide the following information
+                  </CardDescription>
+                </CardHeader>
+                
+                <form onSubmit={handleSubmit}>
+                  <CardContent className="pt-6">
+                    <div className="space-y-6">
+                      {fields.map((field: FormField) => (
+                        <div key={field.id} className="space-y-2">
+                          <Label htmlFor={field.id}>
+                            {field.label}
+                            {field.required && <span className="text-red-500 ml-1">*</span>}
+                          </Label>
+                          
+                          {renderField(field)}
+                          
+                          {errors[field.id] && (
+                            <p className="text-sm text-red-500 flex items-center gap-1">
+                              <AlertCircle className="w-4 h-4" />
+                              {errors[field.id]}
+                            </p>
+                          )}
+                          
+                          {field.type === 'email' && !errors[field.id] && (
+                            <p className="text-xs text-muted-foreground">
+                              We'll never share your email with anyone else.
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                      
+                      {/* Submit Button */}
+                      <div className="pt-6 border-t">
+                        <Button 
+                          type="submit" 
+                          className="w-full"
+                          size="lg"
+                          disabled={submitting}
+                        >
+                          {submitting ? (
+                            <>
+                              <RefreshCw className="w-5 h-5 mr-2 animate-spin" />
+                              Submitting...
+                            </>
+                          ) : (
+                            <>
+                              <Send className="w-5 h-5 mr-2" />
+                              Submit Response
+                            </>
+                          )}
+                        </Button>
+                        
+                        <p className="text-xs text-muted-foreground text-center mt-3">
+                          All {fields.filter(f => f.required).length} required fields must be filled
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </form>
+              </Card>
+            ) : (
+              <Card>
+                <CardContent className="pt-6 text-center">
+                  <p className="text-muted-foreground py-8">No fields in this form</p>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Form Info Footer */}
+            <div className="mt-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                This form is powered by FormBuilder • Your responses are secure and private
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/types/form-submission.ts
+++ b/src/types/form-submission.ts
@@ -1,0 +1,13 @@
+export interface FormSubmission {
+  nodeId: string;
+  id: string;
+  data: Record<string, any>;
+  form_id: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface FormSubmissionInput {
+  data: Record<string, any>;
+  form_id: string;
+}


### PR DESCRIPTION
![form-generator](https://github.com/user-attachments/assets/addc50fd-6531-4f65-8c78-72bb66c48ead)

# PR: feat(form-generator): add form submission page and save responses to Supabase

**Form collection is live — users can now submit responses!**

#### Key Features
- **Public Submission Page** (`/submit/:formId` or similar):
  - Fetches form schema via `GET_FORM_BY_ID` GraphQL query
  - Renders dynamic form fields
  - Client-side validation (required fields)
  - On submit → sends data via `SUBMIT_FORM_RESPONSE` mutation
- **Type Safety**:
  - Added TypeScript interfaces for form submission and responses
- **GraphQL Integration**:
  - New queries/mutations for fetching forms and saving responses
- Clean, responsive UI matching generator style
- Success/error feedback with toast

#### Benefits
- Complete form lifecycle: create → share → collect responses
- Responses securely stored in Supabase
- Ready for future analytics and export features
- No backend changes needed (uses existing tables)

Closes #8 